### PR TITLE
Ajuste para exibir cobertura de testes pelo terminal

### DIFF
--- a/projects/ngx-sp-infra/karma.conf.js
+++ b/projects/ngx-sp-infra/karma.conf.js
@@ -33,17 +33,10 @@ module.exports = function (config) {
       reporters: [
         { type: 'html' },
         { type: 'lcovonly', subdir: '.', file: 'lcov.info' },
+        { type: 'text-summary' }
       ]
     },
     reporters: [ 'progress', 'kjhtml', 'coverage' ],
-    check: {
-      global: {
-        statements: 50,
-        branches: 50,
-        functions: 50,
-        lines: 50
-      }
-    },
     browsers: [ 'Chrome', 'ChromeHeadless' ],
     singleRun: true,
     restartOnFileChange: true,


### PR DESCRIPTION
A informação de cobertura de testes não era exibida mais ao executar os pipelines, ficando zerada também no portal do Sonar.
Corrigi isso adicionando uma propriedade no arquivo **karma.conf.js**.